### PR TITLE
Fixed bug where z ordering was not parsing correctly in the layer name

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -142,10 +142,21 @@ const getElementOptions = (layer, sublayer) => {
   return { blendmode, opacity };
 };
 
+/* Parses the z-layering order 
+  "z2," returns 2  // towards front
+  "2," returns -2  // towards back
+  Otherwise returns null
+*/
 const parseZIndex = (str) => {
   const z = zflag.exec(str);
-  return z ? parseInt(z[0].match(/-?\d+/)[0]) : null;
-};
+  if ( z ) {
+    let zIndex = z[0].indexOf("z")
+    if( zIndex == 0 ) {
+      return parseInt( str.slice(1).match(/-?\d+/)[0] );
+    }
+  }
+
+  return null;
 
 const getElements = (path, layer) => {
   return fs


### PR DESCRIPTION
Layers with z ordering defined were not being parsed correctly. Valid inputs such as `z-10` would result in parseInt("z-10") which would always evaluate to null. Instead the fix removes the z character before attempting to parse an int value. 